### PR TITLE
place Ryan as first author

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -8,25 +8,25 @@ tags:
   - efficient
 
 authors:
+ - name: Ryan R. Curtin
+ - name: Marcus Edel
  - name: Shubham Agrawal
  - name: Suryoday Basak
  - name: James J. Balamuta
  - name: Ryan Birmingham
- - name: Ryan R. Curtin
  - name: Kartik Dutt
  - name: Dirk Eddelbuettel
- - name: Marcus Edel
  - name: Rishabh Garg
  - name: Shikhar Jaiswal
  - name: Aakash Kaushik
  - name: Anjishnu Mukherjee
  - name: Nanubala Gnana Sai
- - name: Conrad Sanderson
  - name: Kim SangYeon
  - name: Nippun Sharma
  - name: Omar Shrit
  - name: Yashwant Singh
  - name: Roshan Swain
+ - name: Conrad Sanderson
 
 affiliations:
 date: 4 November 2022


### PR DESCRIPTION
Alphabetical ordering doesn't really work outside of a few select venues. Ryan is also the main coordinator and progenitor of the mlpack project, so he should get the main credit. This is also for branding purposes, as Ryan's name is a brand of sorts that is closely associated with mlpack.