### PR TITLE
Add affiliation and ORCID iD

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -22,6 +22,8 @@ authors:
    affiliation: 4
  - name: Kartik Dutt
  - name: Dirk Eddelbuettel
+   orcid: 0000-0001-6419-907X
+   affiliation: 7
  - name: Rishabh Garg
  - name: Shikhar Jaiswal
  - name: Aakash Kaushik
@@ -50,6 +52,8 @@ affiliations:
    index: 5
  - name: George Mason University
    index: 6
+ - name: Department of Statistics, University of Illinois, Urbana-Champaign
+   index: 7
 date: 4 November 2022
 bibliography: paper.bib
 


### PR DESCRIPTION
FIY the one for @coatless looks weird to me in the sense that I would use a plural of 'departments' but now that he is an employee of the former maybe we can standardize and (hi there) use one affiliation for both of us?  